### PR TITLE
Fixing Tile walkable status bug

### DIFF
--- a/Assets/Team/Scripts/Gameplay/00_Characters/00_BaseCh/Base_Ch.cs
+++ b/Assets/Team/Scripts/Gameplay/00_Characters/00_BaseCh/Base_Ch.cs
@@ -48,7 +48,8 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
     {
         get { return _currentTileID; }
     }
-    private GridTile currentTile;
+    private GridTile _currentTile;
+    private GridTile _previousTile;
 
 
     private float OffsetValue;
@@ -115,8 +116,8 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
         _previousTileID = _currentTileID;
         _startTileID = _currentTileID;
 
-        currentTile = ref_gridManager.FindTile(_currentTileID);
-        currentTile.SetObjectOccupyingTile(this.gameObject);
+        _currentTile = ref_gridManager.FindTile(_currentTileID);
+        _currentTile.SetObjectOccupyingTile(this.gameObject);
 
         baseRotation = GetComponent<Base_Rotation>();
         startingDirection = _startingDirection;
@@ -124,7 +125,7 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
 
 
 
-        transform.position = new Vector3(currentTile.TilePosition.x, currentTile.TilePosition.y + ySpawnOffset, currentTile.TilePosition.z);
+        transform.position = new Vector3(_currentTile.TilePosition.x, _currentTile.TilePosition.y + ySpawnOffset, _currentTile.TilePosition.z);
 
         _collider = GetComponent<Collider>();
         _meshRenderer = transform.GetChild(0).GetComponent<MeshRenderer>();
@@ -174,7 +175,7 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
     public virtual IEnumerator MoveByAmount(int movementAmount, Vector2 dir, bool wasPushed = false)
     {
         _previousTileID = _currentTileID;
-        currentTile.SetObjectOccupyingTile(null);
+        _previousTile = ref_gridManager.FindTile(_previousTileID);
 
         for (int i = 0; i < movementAmount; i++)
         {
@@ -189,7 +190,7 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
                 Vector3 targetPosition = new Vector3(targetTile.TilePosition.x, desiredLocation.y, targetTile.TilePosition.z);
 
                 _currentTileID = targetTile.TileID;
-                currentTile = ref_gridManager.FindTile(_currentTileID);
+                _currentTile = ref_gridManager.FindTile(_currentTileID);
 
                 yield return StartCoroutine(LerpingMovement(targetPosition, wasPushed));
             }
@@ -201,7 +202,9 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
                 yield break;
             }
         }
-        currentTile.SetObjectOccupyingTile(this.gameObject);
+        _previousTile.UpdateOccupiedStatus(false);
+
+        _currentTile.UpdateOccupiedStatus(true, gameObject);
 
         PlayerMove playerMove = new PlayerMove(true);
         HistoryStack.Push(playerMove);
@@ -266,17 +269,17 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
     {
         if (_currentTileID == _startTileID) 
         {
-            transform.position = new Vector3(currentTile.TilePosition.x, transform.position.y, currentTile.TilePosition.z);
+            transform.position = new Vector3(_currentTile.TilePosition.x, transform.position.y, _currentTile.TilePosition.z);
             return; 
         }
-        currentTile.SetObjectOccupyingTile(null);
+        _currentTile.SetObjectOccupyingTile(null);
 
         _currentTileID = _startTileID;
-        currentTile = ref_gridManager.FindTile(_currentTileID);
+        _currentTile = ref_gridManager.FindTile(_currentTileID);
 
-        currentTile.SetObjectOccupyingTile(this.gameObject);
+        _currentTile.SetObjectOccupyingTile(this.gameObject);
 
-        transform.position = new Vector3(currentTile.TilePosition.x, transform.position.y, currentTile.TilePosition.z);
+        transform.position = new Vector3(_currentTile.TilePosition.x, transform.position.y, _currentTile.TilePosition.z);
 
         ResetRotationToStart();
     }
@@ -312,13 +315,13 @@ public class Base_Ch : MonoBehaviour, IMoveable, IProjectileHittable, IUsableAbi
 
     public void UpdateCurrentTileID()
     {
-        _currentTileID = currentTile.TileID;
+        _currentTileID = _currentTile.TileID;
     }
 
     public void SetCurrentTile(TileID updatedTileID, GridTile updatedGridTile)
     {
         _currentTileID = updatedTileID;
-        currentTile = updatedGridTile;
+        _currentTile = updatedGridTile;
     }
 
 

--- a/Assets/Team/Scripts/Gameplay/00_Characters/00_Enums/Enum_GridDirection.cs
+++ b/Assets/Team/Scripts/Gameplay/00_Characters/00_Enums/Enum_GridDirection.cs
@@ -10,6 +10,9 @@ public enum Enum_GridDirection
     WEST = 3
 }
 
+/// <summary>
+/// Singleton for Direction based utilities: includes returning an Enum based on clockwise or anti clockwise rotation.
+/// </summary>
 public static class DirectionUtilities
 {
     public static Enum_GridDirection RotateClockwise(Enum_GridDirection dir)

--- a/Assets/Team/Scripts/Gameplay/01_Grid/GridTile.cs
+++ b/Assets/Team/Scripts/Gameplay/01_Grid/GridTile.cs
@@ -36,6 +36,7 @@ namespace Team.Gameplay.GridSystem
         public GameObject tilePrefab;
 
         public TileType tileType;
+        private TileType startingTileType;
 
         public TileDirection Direction; //Rotation 
 
@@ -68,6 +69,8 @@ namespace Team.Gameplay.GridSystem
             {
                 objectOccupyingTile.GetComponent<Base_Obstacle>().UpdateObstacleTileData(TileID, this);
             }
+
+            startingTileType = tileType;
 
             //Check if spawn tile
             if (IsTileWalkable())
@@ -195,6 +198,33 @@ namespace Team.Gameplay.GridSystem
         {
             if (!Object) { objectOccupyingTile = null; }
             objectOccupyingTile = Object;
+            SetTileType(TileType.OCCUPIEDTILE);
+        }
+
+        /// <summary>
+        /// Updates the tiles occupied status.
+        /// </summary>
+        /// <param name="isOccupied"></param>
+        /// <param name="OccupyingObject"></param>
+        public void UpdateOccupiedStatus(bool isOccupied = false, GameObject OccupyingObject = null)
+        {
+            switch (isOccupied)
+            {
+                case true:
+                        if (!OccupyingObject) { return; }
+                        objectOccupyingTile = OccupyingObject;
+                        SetTileType(TileType.OCCUPIEDTILE);
+                    break;
+                case false:
+                    objectOccupyingTile = null;
+                    SetTileType(TileType.TILE);
+                    break;
+            }
+        }
+
+        public void ResetTypeToDefault()
+        {
+            tileType = startingTileType;
         }
 
         public void ParentOccupyingObject()

--- a/Assets/Team/Scripts/Gameplay/06_Obstacles/00_BaseObstacle/Base_Obstacle.cs
+++ b/Assets/Team/Scripts/Gameplay/06_Obstacles/00_BaseObstacle/Base_Obstacle.cs
@@ -22,6 +22,7 @@ public class Base_Obstacle : MonoBehaviour, IDestroyable
     public TileID CurrentTileID => _currentTileID;
     [SerializeField]
     protected GridTile _currentGridTile;
+    protected GridTile _previousGridTile;
 
     protected float OffsetValue;
 

--- a/Assets/Team/Scripts/Gameplay/06_Obstacles/MoveableObstacle.cs
+++ b/Assets/Team/Scripts/Gameplay/06_Obstacles/MoveableObstacle.cs
@@ -29,7 +29,6 @@ public class MoveableObstacle : Base_Obstacle, IMoveable
     public IEnumerator MoveByAmount(int movementAmount, Vector2 dir, bool wasPushed)
     {
         _previousTileID = _currentTileID;
-        _currentGridTile.SetObjectOccupyingTile(null);
 
         for (int i = 0; i < movementAmount; i++)
         {
@@ -55,7 +54,9 @@ public class MoveableObstacle : Base_Obstacle, IMoveable
                 yield break;
             }
         }
-        _currentGridTile.SetObjectOccupyingTile(this.gameObject);
+        _previousGridTile.UpdateOccupiedStatus(false);
+
+        _currentGridTile.UpdateOccupiedStatus(true, gameObject);
 
         PlayerMove playerMove = new PlayerMove(true);
         HistoryStack.Push(playerMove);


### PR DESCRIPTION
+ Tiles were not being set as walkable and unwalkable when a character or obstacle was on it.
+ Was fixed by creating a new function on the GridTile that changes the tiles walkable and occupying Object status.