### PR TITLE
Object Clicking fixes and Some Fixing to Fire Spreading

### DIFF
--- a/Assets/Team/Scripts/Gameplay/01_Grid/GridManager.cs
+++ b/Assets/Team/Scripts/Gameplay/01_Grid/GridManager.cs
@@ -42,6 +42,7 @@ namespace Team.Gameplay.GridSystem
         [Header("Gameplay Managers")]
         [SerializeField] private GameObject _fireManager;
         [SerializeField] private GameObject _projectileManager;
+        [SerializeField] private GameObject _ClickableManager;
 
         private void Awake()
         {
@@ -160,6 +161,7 @@ namespace Team.Gameplay.GridSystem
         {
             Instantiate(_fireManager, Vector3.zero, Quaternion.identity, transform.parent);
             Instantiate(_projectileManager, Vector3.zero, Quaternion.identity, transform.parent);
+            Instantiate(_ClickableManager, Vector3.zero, Quaternion.identity, transform.parent);
         }
     }
 }

--- a/Assets/Team/Scripts/Gameplay/06_Obstacles/ExplosiveObject.cs
+++ b/Assets/Team/Scripts/Gameplay/06_Obstacles/ExplosiveObject.cs
@@ -1,4 +1,6 @@
+using Ink.Parsed;
 using System.Collections;
+using System.Collections.Generic;
 using Team.Enum.Character;
 using Team.GameConstants;
 using Team.Gameplay.GridSystem;
@@ -56,6 +58,7 @@ public class ExplosiveObject : MoveableObstacle
     protected void AffectTiles()
     {
         GridTile[] NeighbourTiles = _currentGridTile.FindNeighbouringTiles();
+        List<OilTile> fireOriginTiles = new List<OilTile>();
 
         for(int i = 1; i < NeighbourTiles.Length; i++)
         {
@@ -63,10 +66,9 @@ public class ExplosiveObject : MoveableObstacle
             {
                 if (NeighbourTiles[i].IsOilTile())
                 {
-                    if (!NeighbourTiles[i].GetComponent<OilTile>().isOnFire)
+                    if (NeighbourTiles[i].TryGetComponent(out OilTile oilTile) && !oilTile.isOnFire)
                     {
-                        NeighbourTiles[i].GetComponent<OilTile>().Ignite();
-                        NeighbourTiles[i].GetComponent<OilTile>().visited = true;
+                        fireOriginTiles.Add(oilTile);
                         hasFireStarted = true;
                     }
                 }
@@ -96,7 +98,7 @@ public class ExplosiveObject : MoveableObstacle
         if (hasFireStarted)
         {
             FireSpread.Instance.FireballRef = RefFireballProjectile;
-            FireSpread.Instance.StartFire();
+            FireSpread.Instance.StartFire(fireOriginTiles);
             return;
         }
         RefFireballProjectile.CleanUp();

--- a/Assets/Team/Scripts/Gameplay/07_TileScripts/FireSpread.cs
+++ b/Assets/Team/Scripts/Gameplay/07_TileScripts/FireSpread.cs
@@ -31,12 +31,7 @@ public class FireSpread : MonoBehaviour
         }
     }
 
-    private void Start()
-    {
-        Initialise();
-    }
-
-    private void Initialise()
+    public void Initialise()
     {
         _levelTileCreator = LevelManager.Instance.CreatedLevel.LevelTiles;
         gridWidth = _levelTileCreator.Max_GridSize_Acc.x;
@@ -44,18 +39,25 @@ public class FireSpread : MonoBehaviour
     }
 
     [ContextMenu("Start A Fire!")]
-    public void StartFire()
+    public void StartFire(List<OilTile> originTiles)
     {
-        StartCoroutine(SpreadFire());
+        if (originTiles == null || originTiles.Count == 0) return;
+        StartCoroutine(SpreadFire(originTiles));
     }
 
-    public IEnumerator SpreadFire()
+    public IEnumerator SpreadFire(List<OilTile> startingTiles)
     {
         Queue<OilTile> fireQueue = new Queue<OilTile>();
 
-        for (int x = 0; x <  _levelTileCreator.OilTiles.Count; x++)
+        for (int x = 0; x <  startingTiles.Count; x++)
         {
-             fireQueue.Enqueue(_levelTileCreator.OilTiles[x]);
+            OilTile tile = startingTiles[x];
+            if (tile != null && !tile.isOnFire && !tile.visited)
+            {
+                tile.visited = true;
+                tile.Ignite();
+                fireQueue.Enqueue(tile);
+            }
         }
 
         while (fireQueue.Count > 0)
@@ -66,20 +68,15 @@ public class FireSpread : MonoBehaviour
 
             for (int i = 1; i < neighbours.Length; i++)
             {
-                if (neighbours[i] && neighbours[i].GetComponent<OilTile>())
-                {
-                    OilTile neighbouringOilTile = neighbours[i].GetComponent<OilTile>();                
-
+                if (neighbours[i] && neighbours[i].TryGetComponent(out OilTile neighbouringOilTile))
+                {             
                     if(!neighbouringOilTile.visited && !neighbouringOilTile.isOnFire)
                     {
                         yield return new WaitForSeconds(0.2f);
+
+                        neighbouringOilTile.visited = true;
                         neighbouringOilTile.Ignite();
                         fireQueue.Enqueue(neighbouringOilTile);
-                        neighbouringOilTile.visited = true;
-                    }
-                    if (neighbouringOilTile.visited && neighbouringOilTile.isOnFire)
-                    {
-                        continue;
                     }
                 }
             }

--- a/Assets/Team/Scripts/Gameplay/ObjectClickable.cs
+++ b/Assets/Team/Scripts/Gameplay/ObjectClickable.cs
@@ -56,7 +56,11 @@ public class ObjectClickable : MonoBehaviour
     public void UnhoveredObject()
     {
         if (_ghosting == null) { return; }
-        if (_ghosting.ghostingIsActive && !isHovered){ return;}
+        if (_ghosting.ghostingIsActive && !_ghosting.isHovered)
+        {
+            isHovered = false; 
+            return;
+        }
         isHovered = false;
         _ghosting.isHovered = false;
         onHovered?.Invoke(false);
@@ -67,8 +71,9 @@ public class ObjectClickable : MonoBehaviour
         if (_ghosting == null) { return; }
         if (_ghosting.isHovered)
         {
+            _ghosting.isHovered = false;
             OnEnableClick.Invoke();
-            _ghosting.ghostingIsActive = false;
+            //_ghosting.ghostingIsActive = false;
             return;
         }
         OnDisableClick.Invoke();

--- a/Assets/Team/Scripts/Managers/LevelManager.cs
+++ b/Assets/Team/Scripts/Managers/LevelManager.cs
@@ -174,6 +174,7 @@ namespace Team.Managers
 
                 //Spawn Gameplay Managers.
                 GridManager.Instance.SpawnGameplayManagers();
+                FireSpread.Instance.Initialise();
 
                 // Setup dialogue if available
                 if (CurrentLevel.Info.Data.DialogueAsset != null)

--- a/Assets/Team/Scripts/Managers/ObjectClickerManager.cs
+++ b/Assets/Team/Scripts/Managers/ObjectClickerManager.cs
@@ -71,6 +71,14 @@ public class ObjectClickerManager : MonoBehaviour
 
     private void HoverClickable(bool shouldHover, RaycastHit hit)
     {
+        if(hit.collider.gameObject.GetComponent<ObjectClickable>() != PreviouslyHovered) 
+        {
+            if (PreviousSelectionCanUnhover())
+            {
+                PreviouslyHovered.GetComponent<ObjectClickable>().UnhoveredObject();
+            }
+        }
+
         switch (shouldHover)
         {
             case true:


### PR DESCRIPTION
+ Implemented fix for clicking on objects to enable ghosting effect.
+ Fixed fire spreading, this now functions as intended. It can start at multiple locations and spread out from these locations, without jumping to tiles that it shouldnt spread to etc.
+ Fixed a NRE with the fire manager, that happens when an oil level is completed and then a new oil level is selected. Issue was that it was missing a reference to the current level and didnt get a ref to the new level.
+ Implemented Object clickable spawning on the level spawn, to avoid any bugs from cropping up.